### PR TITLE
Fix test revert call depth

### DIFF
--- a/test/OBRouter.swap.t.sol
+++ b/test/OBRouter.swap.t.sol
@@ -490,6 +490,7 @@ contract OBRouterSwapTest is Test, TestHelpers {
         );
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_RevertInsuficientBalance() external {
         IOBRouter.swapTokenInfo memory tokenInfo = IOBRouter.swapTokenInfo({
             inputToken: TokenHelper.NATIVE_TOKEN,


### PR DESCRIPTION
Foundry has recently patched the behaviour of `expectRevert` cheatcode. This revert check will only work for calls of deeper depth than where the cheatcode is labelled. Thus failing the `test_RevertInsuficientBalance` test. To fix this issue the best approach is to add selectively add an exception to this test as this case reverts due to insufficient native balance transfer which happens at the same call depth as the cheatcode itself (and not at greater depth).

More information on this issue can be found in the documentation below:
https://book.getfoundry.sh/cheatcodes/expect-revert